### PR TITLE
Handle case when a parsed line is all tabs

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -365,13 +365,13 @@ class Parser(object):
 
         # Determine indentation level (count number of tabs).
         level = 0
-        while line[level] == '\t':
+        while level < len(line) and line[level] == '\t':
             level += 1
         match = self._field_regex.match(line[level:])
 
         if match:
             return ParsedField(level, match.group(1), match.group(2) if match.group(2) != " " else None, match.group(3))
-        
+
         # Try to parse array data.
         match = re.match(r"data \s?\((\S+\s?\S*)\) #\d+: .*", line[level:])
         if match:


### PR DESCRIPTION
Encountered this edge case parsing one of our asset bundles

```Traceback (most recent call last):
  File "../../../../asset-bundle-analyzer/analyzer.py", line 1320, in <module>
    main()
  File "../../../../asset-bundle-analyzer/analyzer.py", line 75, in main
    objs = p.parse(datafile + ".txt")
  File "../../../../asset-bundle-analyzer/analyzer.py", line 153, in parse
    self._parse_lines(match[3])
  File "../../../../asset-bundle-analyzer/analyzer.py", line 170, in _parse_lines
    field = self._parse_line(line)
  File "../../../../asset-bundle-analyzer/analyzer.py", line 368, in _parse_line
    while line[level] == '\t':
IndexError: string index out of range```